### PR TITLE
pyqtgraph < 0.10 fail to run `from pyqtgraph import __version__ `, us…

### DIFF
--- a/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
+++ b/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
@@ -43,7 +43,12 @@ if qVersion().startswith('5.'):
         def parse_version(s):
             return [int(x) for x in re.sub(r'(\.0+)*$', '', s).split('.')]
 
-    from pyqtgraph import __version__ as pyqtgraph_version
+    try:
+        from pyqtgraph import __version__ as pyqtgraph_version
+    except:
+        import pkg_resources
+        pyqtgraph_version = pkg_resources.get_distribution("pyqtgraph").version
+
     if parse_version(pyqtgraph_version) < parse_version('0.10.0'):
         raise ImportError('A newer PyQtGraph version is required (at least 0.10 for Qt 5)')
 

--- a/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
+++ b/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
@@ -45,7 +45,9 @@ if qVersion().startswith('5.'):
 
     try:
         from pyqtgraph import __version__ as pyqtgraph_version
-    except:
+    except RuntimeError:
+        # pyqtgraph < 1.0 using Qt4 failing on 16.04 because kinetic uses Qt5.
+        # This raises RuntimeError('the PyQt4.QtCore and PyQt5.QtCore modules both wrap the QObject class')
         import pkg_resources
         pyqtgraph_version = pkg_resources.get_distribution("pyqtgraph").version
 


### PR DESCRIPTION
…e pkg_resources

@dirk-thomas 's fix at https://github.com/ros-visualization/rqt_common_plugins/pull/415 failing on default kinetic enviroment whcih uses 0.9.10 of python-pyqtgraph https://packages.ubuntu.com/xenial/python-pyqtgraph


```
$ rqt_plot /joint_state/position[0]
Traceback (most recent call last):
  File "/opt/ros/kinetic/bin/rqt_plot", line 6, in <module>
    from rqt_plot.plot import Plot
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_plot/plot.py", line 43, in <module>
    from .data_plot import DataPlot
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_plot/data_plot/__init__.py", line 44, in <module>
    from .pyqtgraph_data_plot import PyQtGraphDataPlot
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_plot/data_plot/pyqtgraph_data_plot.py", line 46, in <module>
    from pyqtgraph import __version__ as pyqtgraph_version
  File "/usr/lib/python2.7/dist-packages/pyqtgraph/__init__.py", line 13, in <module>
    from .Qt import QtGui
  File "/usr/lib/python2.7/dist-packages/pyqtgraph/Qt.py", line 104, in <module>
    from PyQt4 import QtGui, QtCore, uic
RuntimeError: the PyQt4.QtCore and PyQt5.QtCore modules both wrap the QObject class
```