### PR TITLE
Registering subscriptions for destruction

### DIFF
--- a/src/rqt_plot/plot.py
+++ b/src/rqt_plot/plot.py
@@ -51,9 +51,10 @@ class Plot(Plugin):
 
         self._context = context
         self._node = context.node
+        self._spinner = context.spinner
         self._args = self._parse_args(context.argv())
-        self._widget = PlotWidget(
-            self._node, initial_topics=self._args.topics, start_paused=self._args.start_paused)
+        self._widget = PlotWidget(self._node, self._spinner, initial_topics=self._args.topics,
+                                  start_paused=self._args.start_paused)
         self._data_plot = DataPlot(self._widget)
 
         # disable autoscaling of X, and set a sane default range

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -155,11 +155,12 @@ def is_plottable(node, topic_name):
 class PlotWidget(QWidget):
     _redraw_interval = 40
 
-    def __init__(self, node, initial_topics=None, start_paused=False):
+    def __init__(self, node, spinner, initial_topics=None, start_paused=False):
         super(PlotWidget, self).__init__()
         self.setObjectName('PlotWidget')
 
         self._node = node
+        self._spinner = spinner
         self._initial_topics = initial_topics
 
         _, package_path = get_resource('packages', 'rqt_plot')
@@ -324,9 +325,11 @@ class PlotWidget(QWidget):
             if topic_name in self._rosdata:
                 qWarning('PlotWidget.add_topic(): topic already subscribed: %s' % topic_name)
                 continue
-            self._rosdata[topic_name] = ROSData(self._node, topic_name, self._start_time)
+            self._rosdata[topic_name] = \
+                ROSData(self._node, self._spinner, topic_name, self._start_time)
             if self._rosdata[topic_name].error is not None:
                 qWarning(str(self._rosdata[topic_name].error))
+                self._rosdata[topic_name].close()
                 del self._rosdata[topic_name]
             else:
                 data_x, data_y = self._rosdata[topic_name].next()

--- a/src/rqt_plot/rosplot.py
+++ b/src/rqt_plot/rosplot.py
@@ -87,11 +87,12 @@ class ROSData(object):
     Subscriber to ROS topic that buffers incoming data
     """
 
-    def __init__(self, node, topic, start_time):
+    def __init__(self, node, spinner, topic, start_time):
         self.name = topic
         self.start_time = start_time
         self.error = None
         self.node = node
+        self.spinner = spinner
 
         self.lock = threading.Lock()
         self.buff_x = []
@@ -106,7 +107,7 @@ class ROSData(object):
             self.error = RosPlotException("Can not resolve topic type of %s" % topic)
 
     def close(self):
-        self.node.destroy_subscription(self.sub)
+        self.spinner.register_listeners_for_destruction(self.sub)
 
     def _ros_cb(self, msg):
         """


### PR DESCRIPTION
This updates rqt_plot to register its subscriptions for destruction with RclpySpinner.

Depends on PR https://github.com/ros-visualization/rqt/pull/184