### PR TITLE
Add support for complex message types

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -114,7 +114,10 @@ def get_plot_fields(node, topic_name):
         slot_type, slot_is_array, array_size = _parse_type(slot_type)
         is_array = slot_is_array and field_index is None
 
-        field_class = topic_helpers.get_type_class(slot_type)
+        if topic_helpers.is_primitive_type(slot_type):
+            field_class = topic_helpers.get_type_class(slot_type)
+        else:
+            field_class = message_helpers.get_message_class(slot_type)
 
     if field_class in (int, float, bool):
         topic_kind = 'boolean' if field_class == bool else 'numeric'


### PR DESCRIPTION
This addresses issue #21 by adding support for complex message types. Attached is an image that shows how you can now plot the fields of subcomponents of messages.


<img width="1220" alt="screen shot 2019-01-02 at 5 29 36 pm" src="https://user-images.githubusercontent.com/1044986/50620431-ff7fa100-0eb3-11e9-9d47-b7ed621aff20.png">
