### PR TITLE
plot_widget: remove kwarg from str.find in parse_type(..)

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -54,7 +54,7 @@ def _parse_type(topic_type_str):
     if array_idx < 0:
         return slot_type, False, None
 
-    end_array_idx = topic_type_str.find(']', start=array_idx + 1)
+    end_array_idx = topic_type_str.find(']', array_idx + 1)
     if end_array_idx < 0:
         return None, False, None
 


### PR DESCRIPTION
As per subject.

At least up to Python 3.7 `find(..)` only takes positional arguments ([docs](https://docs.python.org/3.7/library/stdtypes.html#str.find)).

Triggered by [ros2 crystal rqt_plot error: find() takes no keyword arguments](https://answers.ros.org/question/323177) on ROS Answers.
