### PR TITLE
Compare topics by whole tokens

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -71,7 +71,9 @@ def get_plot_fields(node, topic_name):
     topics = node.get_topic_names_and_types()
     real_topic = None
     for name, topic_types in topics:
-        if name == topic_name[:len(name)]:
+        candidate = name.split('/')
+        desired = topic_name.split('/')
+        if candidate == desired[:len(candidate)]:
             real_topic = name
             topic_type_str = topic_types[0] if topic_types else None
             break


### PR DESCRIPTION
This fixes a bug where topics are not plotted because `get_plot_fields()` tries to get a non-existent field on a topic that happens to be a substring of the one being searched for. This improves the situation by comparing whole tokens.

To reproduce, run each of these commands in a different terminal.

```
ros2 topic pub -r 10 /foo std_msgs/msg/Float32 '{data: 3.14}'
```

```
ros2 topic pub -r 10 /foo_bar std_msgs/msg/Float32 '{data: 1.5}'
```

```
ros2 run rqt_plot rqt_plot /foo_bar/data
```

Without this PR, `rqt_plot` may not display the topic because it tries to look for field `bar/data` on topic `/foo`.