### PR TITLE
Fix exception and a nicer formatting for "Topic" label

### DIFF
--- a/resource/plot.ui
+++ b/resource/plot.ui
@@ -2,14 +2,13 @@
 <ui version="4.0">
  <class>DataPlotWidget</class>
  <widget class="QWidget" name="DataPlotWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>561</width>
-    <height>61</height>
-   </rect>
+  <property name="minimumSize">
+    <size>
+      <width>300</width>
+      <height>200</height>
+    </size>
   </property>
+
   <property name="acceptDrops">
    <bool>true</bool>
   </property>

--- a/resource/plot.ui
+++ b/resource/plot.ui
@@ -34,7 +34,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Topic</string>
+        <string>Topic: </string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fixes an exception that gets thrown when the window is too small for matplotlib to display by setting a minimum window size