### PR TITLE
Fix #35 - "bottom cannot be >= top" matplotlib error

### DIFF
--- a/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/src/rqt_plot/data_plot/mat_data_plot.py
@@ -101,13 +101,30 @@ class MatDataPlot(QWidget):
             super(MatDataPlot.Canvas, self).__init__(Figure())
             self.axes = self.figure.add_subplot(111)
             self.axes.grid(True, color='gray')
-            self.figure.tight_layout()
+            self.do_tight_layout()
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
             self.updateGeometry()
 
         def resizeEvent(self, event):
             super(MatDataPlot.Canvas, self).resizeEvent(event)
-            self.figure.tight_layout()
+            self.do_tight_layout()
+
+        def do_tight_layout(self):
+            """
+            Deal with "ValueError: bottom cannot be >= top" bug in older matplotlib versions
+            (before v2.2.3)
+
+            References:
+                - https://github.com/matplotlib/matplotlib/pull/10915
+                - https://github.com/ros-visualization/rqt_plot/issues/35
+            """
+            if parse_version(matplotlib.__version__) < parse_version('2.2.3'):
+                try:
+                    self.figure.tight_layout()
+                except ValueError:
+                    pass
+            else:
+                self.figure.tight_layout()
 
     limits_changed = Signal()
 


### PR DESCRIPTION
Matplotlib emits errors like the following under specific canvas layouts:

```console
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_plot/data_plot/mat_data_plot.py", line 107, in resizeEvent
    self.figure.tight_layout()
  File "/usr/lib/python2.7/dist-packages/matplotlib/figure.py", line 1756, in tight_layout
    self.subplots_adjust(**kwargs)
  File "/usr/lib/python2.7/dist-packages/matplotlib/figure.py", line 1612, in subplots_adjust
    self.subplotpars.update(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/matplotlib/figure.py", line 230, in update
    raise ValueError('bottom cannot be >= top')
ValueError: bottom cannot be >= top
```

Current patch catches and suppresses the exception.

References:
- https://github.com/matplotlib/matplotlib/pull/10915
- https://github.com/ros-visualization/rqt_plot/issues/35