### PR TITLE
Support bounded and unbounded arrays with rqt_plot (This should NOT be merged to crystal)

### DIFF
--- a/resource/plot.ui
+++ b/resource/plot.ui
@@ -34,7 +34,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Topic</string>
+        <string>Topic: </string>
        </property>
       </widget>
      </item>

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -131,7 +131,6 @@ def get_plot_fields(node, topic_name):
 
         field_class = message_field_type_helpers.get_type_class(slot_type)
 
-    # TODO: add bytes to this as you could treat bytes as an array of uint
     if field_class in (int, float, bool):
         topic_kind = 'boolean' if field_class == bool else 'numeric'
         if is_array:

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -42,7 +42,7 @@ from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QAction, QMenu, QWidget
 
 from rqt_py_common.topic_completer import TopicCompleter
-from rqt_py_common import message_helpers, message_field_type_helpers
+from rqt_py_common import message_helpers, message_field_type_helpers, topic_helpers
 
 from rqt_plot.rosplot import ROSData, RosPlotException, get_topic_type
 
@@ -111,7 +111,7 @@ def get_plot_fields(node, topic_name):
         # parse the field name for an array index
         try:
             field, _, field_index = \
-                message_field_type_helpers.separate_field_from_array_information(field)
+                topic_helpers.separate_field_from_array_information(field)
         except MsgSpecException:
             message = "invalid field %s in topic %s" % (field, real_topic)
             return [], message

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -116,10 +116,12 @@ def get_plot_fields(node, topic_name):
             message = "invalid field %s in topic %s" % (field, real_topic)
             return [], message
 
+        # If it is not a generated msg type
         if not hasattr(field_class, "get_fields_and_field_types"):
             msg = "Invalid field path %s in topic %s" % (field_name, real_topic)
             return [], msg
 
+        # Find the field in the fields of field_class
         fields_and_field_types = field_class.get_fields_and_field_types()
         if field not in fields_and_field_types.keys() :
             message = "no field %s in topic %s" % (field_name, real_topic)
@@ -129,7 +131,8 @@ def get_plot_fields(node, topic_name):
         slot_type, slot_is_array, array_size = _parse_type(slot_type)
         is_array = slot_is_array
 
-        field_class = message_field_type_helpers.get_type_class(slot_type)
+        field_class = message_field_type_helpers.get_field_python_class(
+            slot_type)
 
     if field_class in (int, float, bool):
         topic_kind = 'boolean' if field_class == bool else 'numeric'
@@ -156,7 +159,8 @@ def get_plot_fields(node, topic_name):
             for i, slot in enumerate(fields_and_field_types.keys()):
                 slot_type = fields_and_field_types[slot]
                 slot_type, is_array, array_size = _parse_type(slot_type)
-                slot_class = message_field_type_helpers.get_type_class(slot_type)
+                slot_class = \
+                    message_field_type_helpers.get_field_python_class(slot_type)
                 if slot_class in (int, float) and not is_array:
                     numeric_fields.append(slot)
             message = ""

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -138,8 +138,14 @@ def get_plot_fields(node, topic_name):
         topic_kind = 'boolean' if field_class == bool else 'numeric'
         if is_array:
             if array_size is not None:
-                msg = "topic %s is fixed-size %s array" % (topic_name, topic_kind)
-                return ["%s[%d]" % (topic_name, i) for i in range(array_size)], msg
+                if field_index is None:
+                    msg = "topic %s is a fixed-size %s array" % (topic_name, topic_kind)
+                    return ["%s[%d]" % (topic_name, i) for i in range(array_size)], msg
+                else:
+                    msg = "topic %s is a fixed-size %s array with ix: %s" % (
+                        topic_name, topic_kind, field_index
+                    )
+                    return [topic_name], msg
             else:
                 if field_index is not None:
                     msg = "topic %s is variable-size %s array with ix %d" % (
@@ -345,9 +351,9 @@ class PlotWidget(QWidget):
 
         self.remove_topic_button.setMenu(self._remove_topic_menu)
 
-    def add_topic(self, topic_name):
+    def add_topic(self, field_path):
         topics_changed = False
-        topics, msg = get_plot_fields(self._node, topic_name)
+        topics, msg = get_plot_fields(self._node, field_path)
         if len(topics) == 0:
             qWarning("get_plot_fields failed with msg: %s" % msg)
             return

--- a/src/rqt_plot/rosplot.py
+++ b/src/rqt_plot/rosplot.py
@@ -236,7 +236,7 @@ def generate_field_evals(fields):
         fields = [f for f in fields.split('/') if f]
         for f in fields:
             if '[' in f:
-                field_name, rest = f.split('[')
+                field_name, rest = f.split('[', maxsplit=1)
                 slot_num = int(rest[:rest.find(']')])
                 evals.append(_array_eval(field_name, slot_num))
             else:


### PR DESCRIPTION
This depends on As it depends on https://github.com/ros-visualization/rqt/pull/224

By taking advantage of bounded and unbounded array support in rqt_py_common field parsing, we are able to once again plot values out of variable size arrays with rqt_plot

This change involved more or less reverting rosplot.py, and plot_widget.py to their ros1 equivalents and then using the new RQT_py_common support for dealing with bounded and unbounded arrays. 