### PR TITLE
Set minimum size of MatDataPlot

### DIFF
--- a/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/src/rqt_plot/data_plot/mat_data_plot.py
@@ -134,6 +134,7 @@ class MatDataPlot(QWidget):
         vbox.addWidget(self._toolbar)
         vbox.addWidget(self._canvas)
         self.setLayout(vbox)
+        self.setMinimumSize(self.layout().minimumSize().width() + 1, self.layout().minimumSize().height() + 1 )
 
         self._curves = {}
         self._current_vline = None


### PR DESCRIPTION
When the size of MatDataPlot gets down or below the minimum size of the
QVBoxLayout it contains, the matplot backend fails as it requires a
positive size. The error message is shown in #54.

Explicitly setting the minimumSize of MatDataPlot bigger than the size of the Layout it contains seems
to fix this problem.