### PR TITLE
Replace string.atoi with int()

### DIFF
--- a/src/rqt_plot/rosplot.py
+++ b/src/rqt_plot/rosplot.py
@@ -198,7 +198,7 @@ def generate_field_evals(fields):
         for f in fields:
             if '[' in f:
                 field_name, rest = f.split('[')
-                slot_num = string.atoi(rest[:rest.find(']')])
+                slot_num = int(rest[:rest.find(']')])
                 evals.append(_array_eval(field_name, slot_num))
             else:
                 evals.append(_field_eval(f))

--- a/src/rqt_plot/rosplot.py
+++ b/src/rqt_plot/rosplot.py
@@ -33,7 +33,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-import string
 import sys
 import threading
 import time


### PR DESCRIPTION
string-atoi has been deprecated since Python 2.0 (see here: https://docs.python.org/2/library/string.html#string.atoi)
It is suggested to use the built-in int() function instead. On Python3-only
systems (which will hopefully become more relevant in the near future) this
leads to a crash as atoi has been removed completely.