### PR TITLE
[Noetic] Use catkin_install_python()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,6 @@ install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/rqt_plot
+catkin_install_python(PROGRAMS scripts/rqt_plot
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_plot', 'rqt_plot.data_plot'],
-    package_dir={'': 'src'},
-    scripts=['scripts/rqt_plot']
+    package_dir={'': 'src'}
 )
 
 setup(**d)


### PR DESCRIPTION
Similar to ros-visualization/rqt_graph#43

This uses catkin_install_python() instead of a mix of install and the setup.py scripts argument to make sure the shebang gets rewritten.

It fixes a bug in the current debian package I encountered here: http://wiki.ros.org/ROS/Tutorials/UnderstandingTopics#Using_rqt_plot


@dirk-thomas same question and offer as before: got time to make another Noetic release with this fix? If not, with your permission I can make one.