### PR TITLE
[Noetic] Readd rqt_plot global executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_plot', 'rqt_plot.data_plot'],
-    package_dir={'': 'src'}
+    package_dir={'': 'src'},
+    scripts=['scripts/rqt_plot']
 )
 
 setup(**d)


### PR DESCRIPTION
Reason for adding `scripts` argument back: https://github.com/ros-visualization/rqt_graph/issues/44