### PR TITLE
fix resize bug

### DIFF
--- a/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/src/rqt_plot/data_plot/mat_data_plot.py
@@ -103,6 +103,7 @@ class MatDataPlot(QWidget):
             self.axes.grid(True, color='gray')
             self.safe_tight_layout()
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            self.setMinimumSize(1,1)
             self.updateGeometry()
 
         def resizeEvent(self, event):


### PR DESCRIPTION
This ~~reverts #52 and instead just~~ sets the minimum canvas size to (1,1), which avoids the bugs mentioned in #35 and #54.
This PR takes a similar approach as #56 (which targets the ros2 branch) but sets the minimum size of the canvas widget.