### PR TITLE
Fix matplotlib exception on Windows.

### DIFF
--- a/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/src/rqt_plot/data_plot/mat_data_plot.py
@@ -119,6 +119,8 @@ class MatDataPlot(QWidget):
                 - https://github.com/ros-visualization/rqt_plot/issues/35
             """
             try:
+                if self.figure.get_figheight() == 0 or self.figure.get_figwidth() == 0:
+                    return
                 self.figure.tight_layout()
             except ValueError:
                 if parse_version(matplotlib.__version__) >= parse_version('2.2.3'):


### PR DESCRIPTION
On Windows, when we make the rqt_plot window very small, it
causes matplotlib to throw an exception like:

numpy.linalg.LinAlgError: Singular matrix

The trouble seems to be that the matplotlib resize event is
trying to invert a zero-sized matrix (I think), so it is
giving numpy fits.  If one of the dimensions of the windows
is 0, just skip trying to apply a tight_layout to it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>