### PR TITLE
Fix fixed-size Array visualization

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -123,11 +123,15 @@ def get_plot_fields(node, topic_name):
         if is_array_or_sequence:
             if not has_index:
                 return [], base_error_msg + f'{name} is a nested type but not index provided'
+
             if current_type.has_maximum_size():
-                if index >= current_type.maximum_size:
+                # has_maximum_size() doesn't necessarily mean that the object has a 'maximum_size' field. The meaning
+                # appears to be that the object is bounded in its size and has either a 'maximum_size' or 'size' field.
+                size = current_type.maximum_size if hasattr(current_type, 'maximum_size') else current_type.size
+                if index >= size:
                     return [], (
                         base_error_msg +
-                        f"index '{index}' out of bounds, maximum size is {current_type.maximum_size}")
+                        f"index '{index}' out of bounds, maximum size is {size}")
             current_type = current_type.value_type
         elif has_index:
             return [], base_error_msg + "{name} is not an array or sequence"

--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -122,7 +122,7 @@ def get_plot_fields(node, topic_name):
 
         if is_array_or_sequence:
             if not has_index:
-                return [], base_error_msg + f'{name} is a nested type but not index provided'
+                return [], base_error_msg + f'{name} is a nested type but no index provided'
 
             if current_type.has_maximum_size():
                 # has_maximum_size() doesn't necessarily mean that the object has a 'maximum_size' field. The meaning


### PR DESCRIPTION
Don't assume that has_maximum_size means that a maximum_size field
exists on the object. In the case of an Array object, has_maximum_size
is True, but there is no 'maximum_size' field, only 'size'.

Fixes: #77

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>