### PR TITLE
Fix linalg error 

### DIFF
--- a/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/src/rqt_plot/data_plot/mat_data_plot.py
@@ -120,6 +120,8 @@ class MatDataPlot(QWidget):
                 - https://github.com/ros-visualization/rqt_plot/issues/35
             """
             try:
+                if self.figure.get_figheight() == 0 or self.figure.get_figwidth() == 0:
+                    return
                 self.figure.tight_layout()
             except ValueError:
                 if parse_version(matplotlib.__version__) >= parse_version('2.2.3'):


### PR DESCRIPTION
We encountered an issue that has been fixed in foxy_devel: https://github.com/ros-visualization/rqt_plot/pull/73

Running rqt_plot results in an exception:
```
packages/numpy/linalg/linalg.py", line 88, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
```

This PR cherry picks the fix, and has been verified by two users who were encountering the issue.

fyi @iwanders, @mikepurvis, @jasonimercer