### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rqt_plot</name>
   <version>0.4.14</version>

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-matplotlib</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-matplotlib</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.