### PR TITLE
Fix regression from #87

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -116,7 +116,7 @@ def get_plot_fields(node, topic_name):
         try:
             # This can only be done because the dict is order preserving and all the field name and values
             # are stored in the same order.
-            field_name_index = list(current_message_class.get_fields_and_field_types().keys()).index(f'_{name}')
+            field_name_index = list(current_message_class.get_fields_and_field_types().keys()).index(f'{name}')
         except ValueError:
             return [], no_field_error_msg
         current_type = current_message_class.SLOT_TYPES[field_name_index]


### PR DESCRIPTION
Fixes #89

`list(current_message_class.get_fields_and_field_types().keys())` will return a list where elements are the field names. So when the `topic_type_str` is `sensor_msgs/msg/JointState`, the list will be `['header', 'name', 'position', 'velocity', 'effort']`. So to get the `field_name_index`, we don't need to append a leading `_` to `name`.

This fix works on my local machine:

![rqt_plot_fixed](https://user-images.githubusercontent.com/13482049/236162623-88c664d4-9af9-4b6a-b0a7-2b24e59e989b.png)
