### PR TITLE
Add in a pytest dependency for running tests.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,8 @@
   <exec_depend>rqt_py_common</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <architecture_independent/>
     <build_type>ament_python</build_type>

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'using different plotting backends.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_plot = ' + package_name + '.main:main',


### PR DESCRIPTION
While there aren't currently any tests defined, this sets it up so that they are prepared to use pytest in the future.