### PR TITLE
Revert "Add in a pytest dependency for running tests. (#92)"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,8 +28,6 @@
   <exec_depend>rqt_py_common</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
-  <test_depend>python3-pytest</test_depend>
-
   <export>
     <architecture_independent/>
     <build_type>ament_python</build_type>

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'using different plotting backends.'
     ),
     license='BSD',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_plot = ' + package_name + '.main:main',


### PR DESCRIPTION
This reverts commit 6b54799914644a251c5e19868e51dcabc8de7d81.

The main reason to do this is that on Windows Debug, we don't currently have a Debug wheel for PyQt. Thus these tests always fail on that platform. While the "correct" solution is to build a Windows Debug PyQt wheel, that is a decidedly difficult undertaking. Since we don't have tests to speak of in these packages, avoid the problem for now by just going back to what we were doing before, i.e. using unittest for the tests.

This should fix part of the failing Windows Debug nightlies, like https://ci.ros2.org/view/nightly/job/nightly_win_deb/2999/