### PR TITLE
Add a test dependency on pytest.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,8 @@
   <exec_depend>rqt_py_common</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <architecture_independent/>
     <build_type>ament_python</build_type>

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'using different plotting backends.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_plot = ' + package_name + '.main:main',


### PR DESCRIPTION
While there aren't currently tests defined here, this sets it up so that it is ready for pytest tests.

This will also fix the build on Noble, where these are now hard failures rather than just warnings.