### PR TITLE
Fix listing of nested basic type fields

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -166,7 +166,7 @@ def get_plot_fields(node, topic_name):
         current_msg_keys = current_message_class.get_fields_and_field_types().keys()
         for n_field, n_current_type in zip(current_msg_keys, current_message_class.SLOT_TYPES):
             if isinstance(n_current_type, BasicType):
-                plottable_fields.append(n_field[1:])
+                plottable_fields.append(n_field)
         if plottable_fields:
             return (
                 [f'{topic_name}/{field}' for field in plottable_fields],


### PR DESCRIPTION
From #71, it seems like field names were expected to start with a `_` character, so `n_field[1:]` was meant to get rid of it to get the actual field name. However, there is no leading `_` character. A similar issue was fixed in #90.

This was resulting in the first character being removed from the (sub-/nested) field names, resulting in most of them being invalid:

```
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/ool_value]: 'BasicTypes' object has no attribute 'ool_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/yte_value]: 'BasicTypes' object has no attribute 'yte_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/har_value]: 'BasicTypes' object has no attribute 'har_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/loat32_value]: 'BasicTypes' object has no attribute 'loat32_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/loat64_value]: 'BasicTypes' object has no attribute 'loat64_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/nt8_value]: 'BasicTypes' object has no attribute 'nt8_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/nt16_value]: 'BasicTypes' object has no attribute 'nt16_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/nt32_value]: 'BasicTypes' object has no attribute 'nt32_value'
PlotWidget.update_plot(): error in rosplot: Invalid topic spec [/topic/basic_types_value/nt64_value]: 'BasicTypes' object has no attribute 'nt64_value'
```

![Screenshot from 2025-02-10 15-22-11](https://github.com/user-attachments/assets/3911e0a3-b926-4aec-8503-fe30125ee4f3)

Note that the `uint*` fields were turned into `int*`, so they are still valid.

To validate:

```
$ ros2 topic pub /topic test_msgs/msg/Nested
```

Then run `rqt`, open the `rqt_plot` plugin, enter `/topic/basic_types_value`, and press enter or click the + button. Change the values of the nested fields in the message being published.

----

Note: it seems like the byte value
(`/topic/basic_types_value/byte_value`) cannot be displayed for probably-unrelated reasons:

```
Traceback (most recent call last):
  File "/home/christophe.bedard/ros2_ws/build/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py", line 48, in run
    executor.spin_once(timeout_sec=1.0)
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/executors.py", line 939, in spin_once
    self._spin_once_impl(timeout_sec)
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/executors.py", line 936, in _spin_once_impl
    future.result()  # raise any exceptions
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/task.py", line 101, in result
    raise exception
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/task.py", line 253, in __call__
    handler.send(None)
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/executors.py", line 541, in handler
    await call_coroutine()
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/executors.py", line 429, in _execute
    await await_or_execute(sub.callback, *msg_tuple)
  File "/home/christophe.bedard/ros2_ws/install/rclpy/lib/python3.10/site-packages/rclpy/executors.py", line 112, in await_or_execute
    return callback(*args)
  File "/home/christophe.bedard/ros2_ws/build/rqt_plot/src/rqt_plot/rosplot.py", line 155, in _ros_cb
    self.buff_y.append(self._get_data(msg))
  File "/home/christophe.bedard/ros2_ws/build/rqt_plot/src/rqt_plot/rosplot.py", line 196, in _get_data
    return float(val)
ValueError: could not convert string to float: b'\x00'
```

This fix makes this issue pop up because the field name is now valid. To get around this, click on the - button, and select `/topic/basic_types_value/byte_value` to remove it from the plot. To get the plot values to update again, close (X button in upper right-hand corner) and re-open `rqt`.