### PR TITLE
Fix double slash when plotting all sub-fields with trailing slash

### DIFF
--- a/src/rqt_plot/plot_widget.py
+++ b/src/rqt_plot/plot_widget.py
@@ -171,8 +171,11 @@ def get_plot_fields(node, topic_name):
             if isinstance(n_current_type, BasicType):
                 plottable_fields.append(n_field)
         if plottable_fields:
+            # We try to plot the sub-fields of a field if '/topic/field' or '/topic/field/', so
+            # make sure to remove trailing slashes
+            topic_name_rstrip = topic_name.rstrip('/')
             return (
-                [f'{topic_name}/{field}' for field in plottable_fields],
+                [f'{topic_name_rstrip}/{field}' for field in plottable_fields],
                 f"{len(plottable_fields)} plottable fields in '{topic_name}'"
             )
     if not isinstance(current_type, BasicType):


### PR DESCRIPTION
If topic `/topic` exists, entering `/topic` in the _Topic_ field will result in a "no field specified in topic name '/topic'" validation, since it expects a field. Entering `/topic/` (with a trailing slash) will plot all fields that are "plottable," i.e., primitive (`BasicType`). I think this makes sense, but then we try to plot fields with double slashes.

For example:

```
$ ros2 topic pub /topic test_msgs/msg/BasicTypes
```

Run `rqt`, open the `rqt_plot` plugin, enter `/topic/` and press the + button. The following fields will be added to the plot:

```
/topic//bool_value
/topic//byte_value
/topic//char_value
/topic//float32_value
/topic//float64_value
/topic//int8_value
/topic//uint8_value
/topic//int16_value
/topic//uint16_value
/topic//int32_value
/topic//uint32_value
/topic//int64_value
/topic//uint64_value
```

![Screenshot from 2025-02-11 10-19-06](https://github.com/user-attachments/assets/f9b67a11-1b35-4f13-ab0a-653317b7c37b)

Note the double slashes.

This also happens with sub-fields of a field. For example, publish `test_msgs/msg/Nested` messages and enter `/topic/basic_types_value/`:

```
/topic/basic_types_value//bool_value
/topic/basic_types_value//byte_value
/topic/basic_types_value//char_value
/topic/basic_types_value//float32_value
/topic/basic_types_value//float64_value
/topic/basic_types_value//int8_value
/topic/basic_types_value//uint8_value
/topic/basic_types_value//int16_value
/topic/basic_types_value//uint16_value
/topic/basic_types_value//int32_value
/topic/basic_types_value//uint32_value
/topic/basic_types_value//int64_value
/topic/basic_types_value//uint64_value
```

![Screenshot from 2025-02-11 10-22-07](https://github.com/user-attachments/assets/032c8a43-0b82-4374-8fb1-4733bbf137dd)

Note that we get the correct behaviour if we enter `/topic/basic_types` (no trailing slash) here. That was probably the main use-case, which is why the code adds a slash between the topic name and the field name.

This issue does not really affect the result, since the fields/sub-fields are still plotted just fine. However, removing the trailing slash to avoid a double slash is cleaner.

![Screenshot from 2025-02-11 10-25-11](https://github.com/user-attachments/assets/1a8c658e-1888-4ce3-9116-5fcc39f24513)