### PR TITLE
Fix for displaying constant curves

### DIFF
--- a/src/rqt_plot/data_plot/__init__.py
+++ b/src/rqt_plot/data_plot/__init__.py
@@ -529,6 +529,10 @@ class DataPlot(QWidget):
             y_limit[0] = 0.0
         if numpy.isinf(y_limit[1]):
             y_limit[1] = 1.0
+        # Handle constant curves
+        if abs(y_limit[0] - y_limit[1]) < 1e-8:
+            y_limit[0] -= 0.5
+            y_limit[1] += 0.5
 
         self.set_xlim(x_limit)
         self.set_ylim(y_limit)


### PR DESCRIPTION
I got this warning when displaying a constant curve in rqt_bag:

> /opt/ros/jazzy/lib/python3.12/site-packages/rqt_plot/data_plot/mat_data_plot.py:192: UserWarning: Attempting to set identical low and high ylims makes transformation singular; automatically expanding.
  self._canvas.axes.set_ybound(lower=limits[0], upper=limits[1])

This PR should avoid this error.